### PR TITLE
Support Django 3.0 and recent pytest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: python
-python: 3.5
+python: 3.7
 sudo: false
 
 notifications:
@@ -13,8 +13,10 @@ cache:
     - $HOME/.cache/pip
 
 env:
-  - TOX_ENV=py27-dj111
-  - TOX_ENV=py35-dj111
+  - TOX_ENV=py37-dj22
+  - TOX_ENV=py38-dj22
+  - TOX_ENV=py37-dj30
+  - TOX_ENV=py38-dj30
 
 script:
   - tox -e $TOX_ENV
@@ -26,7 +28,7 @@ deploy:
     secure: nyHO+Ouaq/64fhdwtvvbK5jE+GiLFyah3YC8ibUP4QuOGQcl6CSOLTVhVqmvoCbJQBAQi84KefitnaPK/Jvpbpp3jBKsou5cApoarlTCCqKME9B0P5bQYgYoHBo1xxB0RFpjnbyOYPLYEBKo9aHqh0/R0GUPY8lUALZ7lfp0C4FR8Ogugbm5DRwLh/1V4mBYb/jZOrN2VkFlXwmVDrYWdPAA5Bz9rviu0aXLg7UOyNQIf6qywnPBCpZEHl6eGBG8DdMSniV+mNq9L10ISU9DoaVj7jnrEPFvKxnyFl/a4KeCGvP4kH90/gHuUTU6loet4clGpnXa5/n+5Zq0t5WfOr/3NL1lntCbQmqVniqffPW4nz99rMQ36iLl2Xoz9UTwTEyN7AdkmIIHKVox9hmVfM/npoVwyQEBoY6XnysY9s8yrnqWF3cEzoQzCqOxnt6pF/4aO7aUkfA27W5vwCYDJziGAPT0h62lVDJJvNUfis2mAk5kYqFvJZduqzUcDgivCsHN37wShk//rRAZcrjCbaiOvrLKJsS8A8L6NrDainN+U46GWnerZXr1P3kxw8luwMXKpZXS8MN50Ju2mj/T3YNK66K6EBTY9xT1r5ZXEy7TSJ1rEamPJEpRSddyTRoCxgI7EFrY+zl2AeU4ClBzudPqmmnWWKXsv0vwk/omtFU=
   on:
     tags: true
-    condition: $TOX_ENV = py35-dj111
+    condition: $TOX_ENV = py38-dj30
   distributions: "bdist_wheel"
 before_deploy:
   - 'rm -fr build htmlcov dist .eggs .tox'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: python
-python: 3.7
+python: 3.8
 sudo: false
 
 notifications:
@@ -13,9 +13,7 @@ cache:
     - $HOME/.cache/pip
 
 env:
-  - TOX_ENV=py37-dj22
   - TOX_ENV=py38-dj22
-  - TOX_ENV=py37-dj30
   - TOX_ENV=py38-dj30
 
 script:

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,11 @@
 Change history for django-templateselector
 ------------------------------------------
 
+1.0.0
+^^^^^^
+* |FIX| Remove support for end-of-life Django and Python versions
+* |NEW| Add support for Django 3.0
+
 0.2.5
 ^^^^^^
 * |FIX| Added ``:focus`` visual styles so that keyboard navigation through a form

--- a/demo_project.py
+++ b/demo_project.py
@@ -1,6 +1,5 @@
 #! /usr/bin/env python
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
 import os
 import sys
 sys.dont_write_bytecode = True
@@ -8,15 +7,7 @@ MISSING_DEPENDENCIES = []
 try:
     from django.conf import settings
 except ImportError:
-    MISSING_DEPENDENCIES.append("Django\>=1.11")
-try:
-    from os import scandir
-except ImportError:
-    try:
-        from scandir import scandir
-    except ImportError:
-        MISSING_DEPENDENCIES.append("scandir\>=1.5")
-
+    MISSING_DEPENDENCIES.append("Django\>=2.0")
 
 if MISSING_DEPENDENCIES:
     deps = " ".join(MISSING_DEPENDENCIES)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,4 @@
-[pytest]
+[tool:pytest]
 norecursedirs=.* *.egg .svn _build src bin lib local include
 testpaths=templateselector/tests
 python_files=test_*.py

--- a/setup.py
+++ b/setup.py
@@ -2,25 +2,10 @@
 # -*- coding: utf-8 -*-
 import sys
 import os
-from setuptools import setup, __version__ as setuptools_version
+from setuptools import setup
 from setuptools.command.test import test as TestCommand
 
-INSTALL_REQUIRES = []
-EXTRA_REQUIRES = {}
-scandir = "scandir>=1.5"
-if int(setuptools_version.split(".", 1)[0]) < 18:
-    assert "bdist_wheel" not in sys.argv, "setuptools 18 required for wheels."
-    # For legacy setuptools + sdist.
-    if sys.version_info[0] == 2:
-        INSTALL_REQUIRES.append(scandir)
-else:
-    EXTRA_REQUIRES[":python_version<'3'"] = [scandir]
-
-if sys.version_info[0] == 2:
-    # get the Py3K compatible `encoding=` for opening files.
-    from io import open
 HERE = os.path.abspath(os.path.dirname(__file__))
-
 
 class PyTest(TestCommand):
     def initialize_options(self):
@@ -62,7 +47,7 @@ KEYWORDS = (
 
 setup(
     name="django-templateselector",
-    version="0.2.5",
+    version="1.0.0",
     author="Keryn Knight",
     author_email="django-templateselector@kerynknight.com",
     maintainer="Keryn Knight",
@@ -74,9 +59,8 @@ setup(
     ],
     include_package_data=True,
     install_requires=[
-        "Django>=1.8",
-    ] + INSTALL_REQUIRES,
-    extras_require=EXTRA_REQUIRES,
+        "Django>=2.0",
+    ],
     tests_require=[
         "pytest>=2.6",
         "pytest-django>=2.8.0",
@@ -93,11 +77,9 @@ setup(
         "Intended Audience :: Developers",
         "License :: OSI Approved :: {}".format(LICENSE),
         "Natural Language :: English",
-        "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.5",
         "Framework :: Django",
-        "Framework :: Django :: 1.11",
+        "Framework :: Django :: 2",
+        "Framework :: Django :: 3",
     ],
 )

--- a/templateselector/__init__.py
+++ b/templateselector/__init__.py
@@ -1,11 +1,9 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
-from __future__ import unicode_literals
 
-__version_info__ = '0.2.5'
-__version__ = '0.2.5'
-version = '0.2.5'
-VERSION = '0.2.5'
+__version_info__ = '1.0.0'
+__version__ = '1.0.0'
+version = '1.0.0'
+VERSION = '1.0.0'
 
 def get_version():
     return version  # pragma: no cover

--- a/templateselector/admin.py
+++ b/templateselector/admin.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals, absolute_import
 from django.contrib.admin import AllValuesFieldListFilter, FieldListFilter
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 _ALL = _('All')

--- a/templateselector/fields.py
+++ b/templateselector/fields.py
@@ -1,10 +1,8 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals, absolute_import
 from operator import itemgetter
 from django.conf import settings
 from django.contrib import admin
 from django.contrib.staticfiles import finders
-from django.utils import six
 from django.utils.deconstruct import deconstructible
 from django.utils.module_loading import import_string
 from django.utils.text import capfirst
@@ -20,7 +18,7 @@ from django.template import TemplateDoesNotExist, engines
 from django.template.loader import get_template
 from django.utils.encoding import force_text
 from django.utils.functional import curry
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 __all__ = ['TemplateField', 'TemplateChoiceField']
@@ -78,7 +76,7 @@ class TemplateField(CharField):
         template_exists_validator = TemplateExistsValidator(self.match)
         self.validators.append(template_exists_validator)
 
-        if isinstance(display_name, six.text_type) and '.' in display_name:
+        if isinstance(display_name, str) and '.' in display_name:
             display_name = import_string(display_name)
         if not callable(display_name):
             raise ImproperlyConfigured(_("display_name= argument must be a callable which takes a single string"))
@@ -166,7 +164,7 @@ class TemplateChoiceField(TypedChoiceField):
         max_length = None
         if 'max_length' in kwargs:
             max_length = kwargs.pop('max_length')
-        if isinstance(display_name, six.text_type) and '.' in display_name:
+        if isinstance(display_name, str) and '.' in display_name:
             display_name = import_string(display_name)
         if not callable(display_name):
             raise ImproperlyConfigured(_("display_name= argument must be a callable which takes a single string"))

--- a/templateselector/handlers.py
+++ b/templateselector/handlers.py
@@ -1,21 +1,6 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals, absolute_import
 from django.template.loaders import app_directories, filesystem, cached
-try:
-    from os import scandir
-except ImportError:  # pragma: no cover
-    try:
-        from scandir import scandir
-    except ImportError as e:
-        import sys
-        from django.utils import six
-        message = ("You're probably using Python 2.x, so you'll need to "
-                   "install the backport: `pip install scandir\>=1.5`")
-        flattened = " ".join(e.args) + "\n" + message
-        e.args = (flattened,)
-        e.message = flattened
-        six.reraise(*sys.exc_info())
-
+from os import scandir
 
 __all__ = ['get_results_from_registry']
 

--- a/templateselector/tests/__init__.py
+++ b/templateselector/tests/__init__.py
@@ -1,3 +1,2 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, unicode_literals
 __all__ = []

--- a/templateselector/tests/admin.py
+++ b/templateselector/tests/admin.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals, absolute_import
-
 from django.contrib import admin
 from templateselector.tests.models import MyModel
 

--- a/templateselector/tests/models.py
+++ b/templateselector/tests/models.py
@@ -1,11 +1,8 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals, absolute_import
 from django.db.models import Model
 from django.utils.encoding import force_text
-from django.utils.six import python_2_unicode_compatible
 from templateselector.fields import TemplateField
 
-@python_2_unicode_compatible
 class MyModel(Model):
     f = TemplateField(match="^admin/.+\.html$", verbose_name="test 'f'")
 

--- a/templateselector/tests/test_form_field.py
+++ b/templateselector/tests/test_form_field.py
@@ -21,21 +21,21 @@ def modelcls():
 
 def test_field_warns_if_providing_coerce_callable():
     with pytest.raises(ImproperlyConfigured):
-        TemplateChoiceField(coerce=int, match="^.*$")
+        TemplateChoiceField(coerce=int, match=r"^.*$")
 
 def test_field_warns_if_providing_dumb_display_name():
     with pytest.raises(ImproperlyConfigured):
-        TemplateChoiceField(display_name='goose', match="^.*$")
+        TemplateChoiceField(display_name='goose', match=r"^.*$")
 
 
 def test_field_warns_if_missing_caret_at_start():
     with pytest.raises(ImproperlyConfigured):
-        TemplateChoiceField(match=".*$")
+        TemplateChoiceField(match=r".*$")
 
 
 def test_field_warns_if_missing_dollar_at_end():
     with pytest.raises(ImproperlyConfigured):
-        TemplateChoiceField(match="^.*")
+        TemplateChoiceField(match=r"^.*")
 
 
 def test_model_field_yields_correct_formfield(modelcls):
@@ -46,7 +46,7 @@ def test_model_field_yields_correct_formfield(modelcls):
 
 @override_settings(TEMPLATESELECTOR_DISPLAY_NAMES={'admin/500.html': '500'})
 def test_choices():
-    x = TemplateChoiceField(match="^admin/[0-9]+.html$")
+    x = TemplateChoiceField(match=r"^admin/[0-9]+.html$")
     assert set(x.choices) == {('admin/404.html', '404'), ('admin/500.html', '500')}
 
 
@@ -56,14 +56,14 @@ def test_choices_using_custom_setting_mapping():
         'admin/500.html': 'Server Error',
     }
     with override_settings(TEMPLATESELECTOR_DISPLAY_NAMES=s):
-        x = TemplateChoiceField(match="^admin/[0-9]+.html$")
+        x = TemplateChoiceField(match=r"^admin/[0-9]+.html$")
         assert set(x.choices) == set(s.items())
 
 
 def test_choices_using_custom_namer():
     def namer(data):
         return str(UUID('F'*32))
-    x = TemplateChoiceField(match="^admin/[0-9]+.html$", display_name=namer)
+    x = TemplateChoiceField(match=r"^admin/[0-9]+.html$", display_name=namer)
     assert set(x.choices) == {('admin/404.html', 'ffffffff-ffff-ffff-ffff-ffffffffffff'),
                               ('admin/500.html', 'ffffffff-ffff-ffff-ffff-ffffffffffff')}
 
@@ -72,7 +72,7 @@ def test_choices_using_custom_namer():
 def form_cls():
     class MyForm(Form):
         a = IntegerField()
-        b = TemplateChoiceField(match="^admin/[0-9]+.html$")
+        b = TemplateChoiceField(match=r"^admin/[0-9]+.html$")
     return MyForm
 
 
@@ -96,15 +96,13 @@ def test_admin_default_formfield(rf, modelcls):
     assert isinstance(widget, AdminTemplateSelector)
 
 
-class WidgetTestCase(SimpleTestCase):
-    @skipIf(django.VERSION[0:2] < (1, 11), "won't render properly in Django pre-template-widgets")
-    def test_html_output(self):
-        form = form_cls()(data={'a': '1', 'b': 'admin/404.html'})
-        STATIC_URL = "/TESTOUTPUT/"
-        with override_settings(STATIC_URL=STATIC_URL, TEMPLATESELECTOR_DISPLAY_NAMES={'admin/500.html': '500'}):
-            rendered = force_text(form['b'])
+def test_html_output(form_cls):
+    form = form_cls(data={'a': '1', 'b': 'admin/404.html'})
+    STATIC_URL = "/TESTOUTPUT/"
+    with override_settings(STATIC_URL=STATIC_URL, TEMPLATESELECTOR_DISPLAY_NAMES={'admin/500.html': '500'}):
+        rendered = force_text(form['b'])
 
-        self.assertHTMLEqual(rendered, """
+    SimpleTestCase().assertHTMLEqual(rendered, """
 <ul id="id_b" class="templateselector-list ">
     <li class="templateselector-list-item">
         <label  for="id_b_0" class="templateselector-label">
@@ -126,61 +124,51 @@ class WidgetTestCase(SimpleTestCase):
         """.format(STATIC_URL=STATIC_URL))
 
 
-class WidgetPreselectionTestCase(SimpleTestCase):
-    """
-    If there's only one template choice, and the field is required, pre-select it.
-    Otherwise, don't.
-    """
+def test_pre_selecting_happns_if_only_one_choice_and_required_unbound():
+    class MyForm(Form):
+        field = TemplateChoiceField(
+            match=r"^django/forms/widgets/template_selector.html$",
+            required=True)
 
-    @skipIf(django.VERSION[0:2] < (1, 11), "won't render properly in Django pre-template-widgets")
-    def test_pre_selecting_happns_if_only_one_choice_and_required_unbound(self):
-        class MyForm(Form):
-            field = TemplateChoiceField(
-                match="^django/forms/widgets/template_selector.html$",
-                required=True)
+    form = MyForm(data=None)
+    rendered = force_text(form['field'])
+    SimpleTestCase().assertInHTML('<input type="radio" name="field" value="django/forms/widgets/template_selector.html" required checked id="id_field_0" />', rendered, count=1)
 
-        form = MyForm(data=None)
-        rendered = force_text(form['field'])
-        self.assertInHTML('<input type="radio" name="field" value="django/forms/widgets/template_selector.html" required checked id="id_field_0" />', rendered, count=1)
+def test_no_pre_selecting_occurs_for_more_than_one_choice():
+    class MyForm(Form):
+        field = TemplateChoiceField(
+            match=r"^django/forms/widgets/template_.+\.html$",
+            required=True)
 
-    @skipIf(django.VERSION[0:2] < (1, 11), "won't render properly in Django pre-template-widgets")
-    def test_no_pre_selecting_occurs_for_more_than_one_choice(self):
-        class MyForm(Form):
-            field = TemplateChoiceField(
-                match="^django/forms/widgets/template_.+\.html$",
-                required=True)
+    form = MyForm(data=None)
+    rendered = force_text(form['field'])
+    SimpleTestCase().assertInHTML('<input type="radio" name="field" value="django/forms/widgets/template_selector.html" required id="id_field_0" />', rendered, count=1)
+    SimpleTestCase().assertInHTML('<input type="radio" name="field" value="django/forms/widgets/template_selector_option.html" required id="id_field_1" />', rendered, count=1)
 
-        form = MyForm(data=None)
-        rendered = force_text(form['field'])
-        self.assertInHTML('<input type="radio" name="field" value="django/forms/widgets/template_selector.html" required id="id_field_0" />', rendered, count=1)
-        self.assertInHTML('<input type="radio" name="field" value="django/forms/widgets/template_selector_option.html" required id="id_field_1" />', rendered, count=1)
+def test_no_pre_selecting_if_field_is_not_required():
+    class MyForm(Form):
+        field = TemplateChoiceField(
+            match=r"^django/forms/widgets/template_selector.html$",
+            required=False)
 
-    @skipIf(django.VERSION[0:2] < (1, 11), "won't render properly in Django pre-template-widgets")
-    def test_no_pre_selecting_if_field_is_not_required(self):
-        class MyForm(Form):
-            field = TemplateChoiceField(
-                match="^django/forms/widgets/template_selector.html$",
-                required=False)
+    form = MyForm(data=None)
+    rendered = force_text(form['field'])
+    SimpleTestCase().assertInHTML('<input type="radio" name="field" value="django/forms/widgets/template_selector.html" id="id_field_0" />', rendered, count=1)
 
-        form = MyForm(data=None)
-        rendered = force_text(form['field'])
-        self.assertInHTML('<input type="radio" name="field" value="django/forms/widgets/template_selector.html" id="id_field_0" />', rendered, count=1)
+def test_no_pre_selecting_happens_for_bound_forms():
+    class MyForm(Form):
+        field = TemplateChoiceField(
+            match=r"^django/forms/widgets/template_.+\.html$",
+            required=False)
 
-    @skipIf(django.VERSION[0:2] < (1, 11), "won't render properly in Django pre-template-widgets")
-    def test_no_pre_selecting_happens_for_bound_forms(self):
-        class MyForm(Form):
-            field = TemplateChoiceField(
-                match="^django/forms/widgets/template_.+\.html$",
-                required=False)
-
-        form = MyForm(data={'field': 'django/forms/widgets/template_selector_option.html'})
-        rendered = force_text(form['field'])
-        self.assertInHTML('<input type="radio" name="field" value="django/forms/widgets/template_selector.html" id="id_field_0" />', rendered, count=1)
-        self.assertInHTML('<input type="radio" name="field" value="django/forms/widgets/template_selector_option.html" checked id="id_field_1" />', rendered, count=1)
+    form = MyForm(data={'field': 'django/forms/widgets/template_selector_option.html'})
+    rendered = force_text(form['field'])
+    SimpleTestCase().assertInHTML('<input type="radio" name="field" value="django/forms/widgets/template_selector.html" id="id_field_0" />', rendered, count=1)
+    SimpleTestCase().assertInHTML('<input type="radio" name="field" value="django/forms/widgets/template_selector_option.html" checked id="id_field_1" />', rendered, count=1)
 
 
 def test_no_duplicates():
-    field = TemplateChoiceField(match="^django/forms/widgets/template_.+\.html$")
+    field = TemplateChoiceField(match=r"^django/forms/widgets/template_.+\.html$")
     assert list(field.choices) == [
         (u'django/forms/widgets/template_selector.html', u'Template selector'),
         (u'django/forms/widgets/template_selector_option.html', u'Template selector option'),

--- a/templateselector/tests/test_form_field.py
+++ b/templateselector/tests/test_form_field.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals, absolute_import
-
 from unittest import skipIf
 from uuid import UUID
 

--- a/templateselector/tests/test_model_field.py
+++ b/templateselector/tests/test_model_field.py
@@ -4,6 +4,7 @@ import pytest
 from django.contrib.admin import ModelAdmin, AdminSite
 from django.contrib.admin.templatetags.admin_list import result_headers
 from django.contrib.admin.views.main import ChangeList
+from django.contrib.auth.models import AnonymousUser
 
 from django.core.exceptions import ValidationError, ImproperlyConfigured
 from django.template import TemplateDoesNotExist
@@ -37,6 +38,7 @@ def modelclsadmin(modelcls):
 @pytest.yield_fixture
 def modelclschangelist(rf, modelclsadmin):
     request = rf.get('/')
+    request.user = AnonymousUser()
     cl_cls = modelclsadmin.get_changelist(request=request)
     cl = cl_cls(request=request, model=modelclsadmin.model,
                 list_display=modelclsadmin.list_display,
@@ -44,7 +46,8 @@ def modelclschangelist(rf, modelclsadmin):
                 date_hierarchy=None, search_fields=None,
                 list_select_related=False, list_per_page=5,
                 list_max_show_all=5, list_editable=(),
-                model_admin=modelclsadmin)
+                model_admin=modelclsadmin,
+                sortable_by=("pk", "f",))
     yield cl
 
 

--- a/templateselector/tests/test_model_field.py
+++ b/templateselector/tests/test_model_field.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals, absolute_import
-
 import pickle
 import pytest
 from django.contrib.admin import ModelAdmin, AdminSite

--- a/templateselector/widgets.py
+++ b/templateselector/widgets.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals, absolute_import
 from django.forms import RadioSelect
 
 

--- a/test_settings.py
+++ b/test_settings.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals, absolute_import
 import os
 
 DEBUG = os.environ.get('DEBUG', 'on') == 'on'

--- a/test_urls.py
+++ b/test_urls.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals, absolute_import
 from django.conf.urls import url, include
 from django.contrib import admin
 from django.forms import Form

--- a/tox.ini
+++ b/tox.ini
@@ -1,14 +1,17 @@
 [tox]
 minversion=2.2
-envlist = py27-dj111,
-          py35-dj111,
+envlist = py37-dj22,
+          py37-dj30,
+          py38-dj22,
+          py38-dj30,
 [testenv]
 commands =
     python -B -R -tt -W ignore setup.py test
 
 basepython =
-    py27: python2.7
-    py35: python3.5
+    py37: python3.7
+    py38: python3.8
 
 deps =
-    dj111: Django>=1.11,<2.0
+    dj22: Django>=2.2,<3.0
+    dj30: Django>=3.0,<4.0


### PR DESCRIPTION
This ports all parts of the project to support Django 3.0 and the tests for current pytest versions. Doing so, it drops support for Python 2 and Django 1.11, as Python 2 is end of life and DJango 1.11 soon will be.

I bumped the semantic version to 1.0.0 because this is a breaking change.

Closes #5.